### PR TITLE
Add some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ local opts = {
     highlight_group = "RadarMark",
     background_highlight = true,                    
     background_highlight_group = "RadarBackground", 
+    text_position = "overlay",
 }
 ```
 
@@ -56,9 +57,11 @@ You can pass a table in `setup()` to override the default configuration.
     require("mark-radar").setup(opts)
 ```
 
+Possible values for text_position are `"eol"`, `"overlay"`, `"right_align"`, and `"inline"`. See the `virt_text_pos` description in `:h nvim_buf_set_extmark` for more information.
+
 ## Usage
 
-The default mapping to activate mark-radar is the `` backtick/grave key (`) ``
+The default mappings to activate mark-radar are the `` backtick/grave key (`) `` and the `apostrophe key (')`
 
 ## Inspiration
 


### PR DESCRIPTION
There was an undocumented option in the config, so I added an explanation for it.

It was also not clear that the default mapping includes both <kbd>\`</kbd> _and_ <kbd>'</kbd>, so I added a note for that.