### PR TITLE
Preserve default mark jump behavior of vim

### DIFF
--- a/lua/mark-radar/motion.lua
+++ b/lua/mark-radar/motion.lua
@@ -2,7 +2,8 @@ local function jump(mark_list, str, to_column)
 	for _, mark in ipairs(mark_list) do
 		if str == mark.mark:sub(2) then
 			local line, col = mark.pos[2], mark.pos[3] - 1
-            local target_col = to_column and col or 0
+            local first_char_col = vim.fn.indent(vim.fn.line("'" .. str))
+            local target_col = to_column and col or first_char_col
             vim.api.nvim_win_set_cursor(0, { line, target_col })
 		end
 	end


### PR DESCRIPTION
When jumping with <kbd>\`</kbd>, the default vim behavior is to go to the first non-blank character in the line. This plugin jumps to column 0 instead of the column with the first non-blank character.

See [this comment](https://github.com/winston0410/mark-radar.nvim/issues/4#issuecomment-1917516534) for context.