### PR TITLE
Show marks at the position that you will jump to

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ local opts = {
     highlight_group = "RadarMark",
     background_highlight = true,                    
     background_highlight_group = "RadarBackground", 
+    show_marks_at_jump_positions = true,
 }
 ```
 

--- a/lua/mark-radar/init.lua
+++ b/lua/mark-radar/init.lua
@@ -26,9 +26,12 @@ local function setup(user_opts)
 	end
 end
 
-local function highlight_marks(mark_list, top_line, bottom_line)
+local function highlight_marks(mark_list, top_line, bottom_line, jump_to_column)
 	for _, mark in ipairs(mark_list) do
 		local line, col = mark.pos[2] - 1, mark.pos[3] - 1
+        if(opts.show_marks_at_jump_positions and not jump_to_column) then
+            col = vim.fn.indent(vim.fn.line(mark.mark))
+        end
 		local column_count = string.len(vim.api.nvim_buf_get_lines(0, line, line + 1, false)[1])
 		if line < bottom_line and col < column_count then
 			local extmark_id = vim.api.nvim_buf_set_extmark(0, ns, line, col, {
@@ -67,7 +70,7 @@ local function scan(jump_to_column)
 		)
 	end
 
-	highlight_marks(mark_list, top_line, bottom_line)
+	highlight_marks(mark_list, top_line, bottom_line, jump_to_column)
 
 	while not input do
 		local ok, key = pcall(vim.fn.getchar)

--- a/lua/mark-radar/opts.lua
+++ b/lua/mark-radar/opts.lua
@@ -1,9 +1,10 @@
 local opts = {
-    set_default_mappings       = true,
-	highlight_group            = "RadarMark",
-	background_highlight       = true,
-    background_highlight_group = "RadarBackground",
-    text_position              = "overlay"
+    set_default_mappings         = true,
+	highlight_group              = "RadarMark",
+	background_highlight         = true,
+    background_highlight_group   = "RadarBackground",
+    text_position                = "overlay",
+    show_marks_at_jump_positions = true,
 }
 
 return opts


### PR DESCRIPTION
I added an option to show the marks at the position that you will jump to. When jumping with the <kbd>\`</kbd> key, you will jump to the location of the mark, but when jumping with the <kbd>'</kbd> key, you will jump to the _line_ of the mark. When the new option (`show_marks_at_jump_position`) is enabled, the mark highlights will show at the exact location that the cursor is going to jump to. When the option is disabled, they will show at the marked location, as before.

This is dependent on pull request #9.

This should close issue #4.