### PR TITLE
wrap nvim_win_set_cursor in pcall

### DIFF
--- a/lua/mark-radar/motion.lua
+++ b/lua/mark-radar/motion.lua
@@ -4,9 +4,9 @@ local function jump(mark_list, str, to_column)
             local line, col = mark.pos[2], mark.pos[3] - 1
             local first_char_col = vim.fn.indent(vim.fn.line("'" .. str))
             local target_col = to_column and col or first_char_col
-            local success, errMsg = pcall(function() vim.api.nvim_win_set_cursor(0, { line, target_col }) end)
+            local success, err_msg = pcall(function() vim.api.nvim_win_set_cursor(0, { line, target_col }) end)
             if not success then
-              print(errMsg)
+              print(err_msg)
             end
         end
     end

--- a/lua/mark-radar/motion.lua
+++ b/lua/mark-radar/motion.lua
@@ -4,7 +4,10 @@ local function jump(mark_list, str, to_column)
             local line, col = mark.pos[2], mark.pos[3] - 1
             local first_char_col = vim.fn.indent(vim.fn.line("'" .. str))
             local target_col = to_column and col or first_char_col
-            vim.api.nvim_win_set_cursor(0, { line, target_col })
+            local success, errMsg = pcall(function() vim.api.nvim_win_set_cursor(0, { line, target_col }) end)
+            if not success then
+              print(errMsg)
+            end
         end
     end
 end


### PR DESCRIPTION
Addresses https://github.com/winston0410/mark-radar.nvim/issues/6

Marks can become invalid in which case `vim.api.nvim_win_set_cursor` will error.
I'm no expert on marks, but one way I was able to provoke marks to become invalid, is by deleting the last line of a buffer, in which case the `.` mark become invalid.

Perhaps there are other scenarios in which the `vim.api.nvim_win_set_cursor` call will fail, and we would probably always want the cleanup to happen so this wraps the call with `pcall`.