### PR TITLE
Free the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,37 +1,16 @@
-Modified MIT License
+MIT License
 
-Copyright (c) John Winston and/or Kyle Kovacs
+Copyright (c) 2026 John Winston and/or Kyle Kovacs
 
-Permission is hereby granted, free of charge, to any individual or legal entity
-obtaining a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including without
-limitation the rights to use, copy, modify, merge, publish, distribute,
-sublicense, and/or sell copies of the Software, and to permit persons to whom
-the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-2. The individual or the legal entity must strictly comply with all applicable
-   laws, regulations, rules and standards of the jurisdiction relating to labor
-   and employment where the individual is physically located or where the
-   individual was born or naturalized; or where the legal entity is registered
-   or is operating (whichever is stricter). In case that the jurisdiction has
-   no such laws, regulations, rules and standards or its laws, regulations,
-   rules and standards are unenforceable, the individual or the legal entity
-   are required to comply with Core International Labor Standards.
-
-3. The individual or the legal entity shall not induce, suggest, or force its
-   employee(s), whether full-time or part-time, or its independent
-   contractor(s), in any methods, to agree in oral or written form, to directly
-   or indirectly restrict, weaken or relinquish his or her rights or remedies
-   under such laws, regulations, rules and standards relating to labor and
-   employment as mentioned above, no matter whether such written or oral
-   agreements are enforceable under the laws of the said jurisdiction, nor
-   shall such individual or the legal entity limit, in any methods, the rights
-   of its employee(s) or independent contractor(s) from reporting or
-   complaining to the copyright holder or relevant authorities monitoring the
-   compliance of the license about its violation(s) of the said license.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -40,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
Following the request from https://github.com/winston0410/mark-radar.nvim/issues/20#issuecomment-4465090805, I propose a change to remove all modifications from the original license and relicense to a fully FOSS MIT license. 

As the current maintainer does not care for the license (see comment linked above), relicensing should not pose a problem.

cc @t184256